### PR TITLE
Allow Slack backend to optionally use immutable userids for ACLs

### DIFF
--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -153,6 +153,8 @@ class SlackPerson(Person):
     def aclattr(self):
         # Note: Don't use str(self) here because that will return
         # an incorrect format from SlackMUCOccupant.
+        if self.bot_config.ACCESS_CONTROLS_USE_SLACK_USERID:
+            return self.userid
         return f'@{self.username}'
 
     @property

--- a/errbot/bootstrap.py
+++ b/errbot/bootstrap.py
@@ -25,6 +25,8 @@ def bot_config_defaults(config):
         config.ACCESS_CONTROLS_DEFAULT = {}
     if not hasattr(config, 'ACCESS_CONTROLS'):
         config.ACCESS_CONTROLS = {}
+    if not hasattr(config, 'ACCESS_CONTROLS_USE_SLACK_USERID'):
+        config.ACCESS_CONTROLS_USE_SLACK_USERID = False
     if not hasattr(config, 'HIDE_RESTRICTED_COMMANDS'):
         config.HIDE_RESTRICTED_COMMANDS = False
     if not hasattr(config, 'HIDE_RESTRICTED_ACCESS'):


### PR DESCRIPTION
Same as https://github.com/errbotio/errbot/pull/399 but for our fork.